### PR TITLE
Fix CLI pointer

### DIFF
--- a/generator/cli/kallax/cmd.go
+++ b/generator/cli/kallax/cmd.go
@@ -26,8 +26,8 @@ func newApp() *cli.App {
 	app.Flags = cmd.Generate.Flags
 	app.Action = cmd.Generate.Action
 	app.Commands = cli.Commands{
-		cmd.Generate,
-		cmd.Migrate,
+		&cmd.Generate,
+		&cmd.Migrate,
 	}
 
 	return app

--- a/generator/cli/kallax/cmd/gen.go
+++ b/generator/cli/kallax/cmd/gen.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"os"
+
 	"gopkg.in/src-d/go-kallax.v1/generator"
 	cli "gopkg.in/urfave/cli.v1"
-	"os"
 )
 
 var Generate = cli.Command{
@@ -14,17 +15,17 @@ var Generate = cli.Command{
 	Usage:  "Generate kallax models",
 	Action: generateAction,
 	Flags: []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "input",
 			Value: ".",
 			Usage: "Input package directory",
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "output",
 			Value: "kallax.go",
 			Usage: "Output file name",
 		},
-		cli.StringSliceFlag{
+		&cli.StringSliceFlag{
 			Name:  "exclude, e",
 			Usage: "List of excluded files from the package when generating the code for your models. Use this to exclude files in your package that uses the generated code. You can use this flag as many times as you want.",
 		},

--- a/generator/cli/kallax/cmd/migrate.go
+++ b/generator/cli/kallax/cmd/migrate.go
@@ -17,41 +17,41 @@ var Migrate = cli.Command{
 	Usage:  "Generate migrations for current kallax models",
 	Action: migrateAction,
 	Flags: []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "out, o",
 			Usage: "Output directory of migrations",
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "name, n",
 			Usage: "Descriptive name for the migration",
 			Value: "migration",
 		},
-		cli.StringSliceFlag{
+		&cli.StringSliceFlag{
 			Name:  "input, i",
 			Usage: "List of directories to scan models from. You can use this flag as many times as you want.",
 		},
 	},
 	Subcommands: cli.Commands{
-		Up,
-		Down,
+		&Up,
+		&Down,
 	},
 }
 
 var migrationFlags = []cli.Flag{
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "dir, d",
 		Value: "./migrations",
 		Usage: "Directory where your migrations are stored",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "dsn",
 		Usage: "PostgreSQL data source name. Example: `user:pass@localhost:5432/database?sslmode=enable`",
 	},
-	cli.UintFlag{
+	&cli.UintFlag{
 		Name:  "steps, n",
 		Usage: "Number of migrations to run",
 	},
-	cli.UintFlag{
+	&cli.UintFlag{
 		Name:  "version, v",
 		Usage: "Migrate to a specific version. If `steps` and this flag are given, this will be used.",
 	},
@@ -61,7 +61,7 @@ var Up = cli.Command{
 	Name:   "up",
 	Usage:  "Executes the migrations from the current version until the specified version.",
 	Action: runMigrationAction(upAction),
-	Flags: append(migrationFlags, cli.BoolFlag{
+	Flags: append(migrationFlags, &cli.BoolFlag{
 		Name:  "all",
 		Usage: "If this flag is used, the database will be migrated all the way up.",
 	}),


### PR DESCRIPTION
From one to another day, starts failing:

```
# gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/gen.go:17:17: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/gen.go:22:17: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/gen.go:27:22: cannot use cli.StringSliceFlag literal (type cli.StringSliceFlag) as type cli.Flag in array or slice literal:
	cli.StringSliceFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/migrate.go:20:17: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/migrate.go:24:17: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/migrate.go:29:22: cannot use cli.StringSliceFlag literal (type cli.StringSliceFlag) as type cli.Flag in array or slice literal:
	cli.StringSliceFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/migrate.go:41:16: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/migrate.go:46:16: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/migrate.go:50:14: cannot use cli.UintFlag literal (type cli.UintFlag) as type cli.Flag in array or slice literal:
	cli.UintFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/migrate.go:54:14: cannot use cli.UintFlag literal (type cli.UintFlag) as type cli.Flag in array or slice literal:
	cli.UintFlag does not implement cli.Flag (Apply method has pointer receiver)
/go/src/gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd/migrate.go:54:14: too many errors
cp: can't stat '/go/bin/kallax': No such file or directory
The command '/bin/sh -c apk update && apk add --no-cache git sed build-base gcc wget;    go get -u     github.com/golang/dep/cmd/dep     gopkg.in/src-d/go-kallax.v1/...;    go install gopkg.in/src-d/go-kallax.v1/;    cp $GOPATH/bin/kallax /bin/kallax' returned a non-zero code: 1
ERROR
```


And, as you can see in this DRAFT PR which uses this branch, it's working now.:
- https://github.com/loyalguru/loyal-guru-api-streaming-v2/pull/784